### PR TITLE
Replace env_bind_fns with env_bind_active

### DIFF
--- a/R/conflicts.R
+++ b/R/conflicts.R
@@ -22,7 +22,7 @@ register_conflicts <- function() {
 
   # For each conflicted, new active binding in shim environment
   conflict_overrides <- Map(conflict_fun, names(conflicts), conflicts)
-  env_bind_fns(env, !!! conflict_overrides)
+  env_bind_active(env, !!! conflict_overrides)
 
   # Shim library() and require() so we can rebuild
   env_bind(env,
@@ -99,5 +99,3 @@ conflict_fun <- function(name, pkgs) {
     )
   }
 }
-
-

--- a/R/shims.R
+++ b/R/shims.R
@@ -17,7 +17,7 @@ register_shims <- function() {
 }
 
 register_shim_T_F <- function(env) {
-  env_bind_fns(env,
+  env_bind_active(env,
     T = function() strict_abort("Please use TRUE, not T"),
     F = function() strict_abort("Please use FALSE, not F")
   )

--- a/tests/testthat/test-lax.R
+++ b/tests/testthat/test-lax.R
@@ -2,6 +2,6 @@ context("lax")
 
 test_that("lax suppresses warnings too", {
   df <- data.frame(xyz = 1)
-  expect_warning(df$x, "Partial match")
+  expect_warning(df$x, "partial match")
   expect_warning(lax(df$x), NA)
 })


### PR DESCRIPTION
I replaced calls to the `rlang` function `env_bind_fns` with the renamed version, `env_bind_active`.

I also changed the expected warning message in a test, because the generated warning has changed.

Fixes #38 